### PR TITLE
Updating to latest rascal, rascal-maven-plugin, and salix-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,12 +33,12 @@
         <dependency>
             <groupId>org.rascalmpl</groupId>
             <artifactId>rascal</artifactId>
-            <version>0.40.14</version>
+            <version>0.40.17</version>
         </dependency>
         <dependency>
             <groupId>org.rascalmpl</groupId>
             <artifactId>salix-core</artifactId>
-            <version>0.2.6</version>
+            <version>0.2.7</version>
         </dependency>
     </dependencies>
 
@@ -77,7 +77,7 @@
             <plugin>
                 <groupId>org.rascalmpl</groupId>
                 <artifactId>rascal-maven-plugin</artifactId>
-                <version>0.28.8</version>
+                <version>0.28.9</version>
                 <configuration>
                     <errorsAsWarnings>true</errorsAsWarnings>
                     <bin>${project.build.outputDirectory}</bin>


### PR DESCRIPTION
Updated to
* `rascal`:  0.40.17
* `rascal-maven-plugin`: 0.28.9
* `salix-core`: 0.2.7